### PR TITLE
🐛 Fix: 매물 조회 가격대 필터링 오류 수정

### DIFF
--- a/src/pages/propertySearch/PropertySearch.vue
+++ b/src/pages/propertySearch/PropertySearch.vue
@@ -4,9 +4,7 @@ import axios from 'axios'
 import Filtering from '@/components/filters/FilterBarSearch.vue'
 import PropertyCard from '@/components/cards/PropertyCard.vue'
 
-import { usePropertyStore } from '@/stores/property'
 import { usePriceStore } from '@/stores/priceStore'
-import { storeToRefs } from 'pinia'
 
 import districtData from '@/assets/data/district.json'
 
@@ -15,15 +13,12 @@ const onlySecure = ref(false)
 const region = ref({ city: null, district: null, parish: null })
 const propertyList = ref([]) // 백엔드에서 받아온 응답 결과(매물 데이터)를 저장할 상태
 
-
 const address = ref({
   sido: sessionStorage.getItem('sido') || '서울특별시',
   sigungu: sessionStorage.getItem('sigungu') || '강남구',
   eupmyendong: sessionStorage.getItem('eupmyendong') || '논현동',
 })
 
-const propertyStore = usePropertyStore()
-// const { address } = storeToRefs(propertyStore)
 const priceStore = usePriceStore()
 const isLoading = ref(false)
 const hasMore = ref(true)
@@ -37,7 +32,6 @@ const md = computed(
 const mr = computed(
   () => priceStore.states.monthlyRent ?? { min: null, max: null },
 )
-
 
 // 예시 더미 데이터
 const dummyDistricts = districtData
@@ -107,7 +101,6 @@ function handleRegionUpdate(updatedRegion) {
   region.value = updatedRegion
 }
 
-
 function updateDealType(val) {
   dealType.value = [...val]
 }
@@ -124,17 +117,10 @@ function handleOnlySecureUpdate(val) {
   fetchProperties()
 }
 
-// 백엔드 API 요청
-function fetchProperties() {
-  const params = {
-    transactionType: getMappedTransactionType(dealType.value),
-    jeonseDepositMin: priceStore.states.jeonseDeposit.min,
-    jeonseDepositMax: priceStore.states.jeonseDeposit.max,
-    monthlyDepositMin: priceStore.states.monthlyDeposit.min,
-    monthlyDepositMax: priceStore.states.monthlyDeposit.max,
-    monthlyRentMin: priceStore.states.monthlyRent.min,
-    monthlyRentMax: priceStore.states.monthlyRent.max,
+const toWon = v =>
+  v === null || v === undefined || v === '' ? undefined : Number(v) * 10000
 
+// 백엔드 API 요청
 function fetchProperties(isLoadMore = false) {
   if (isLoading.value || (!hasMore.value && isLoadMore)) return
   isLoading.value = true
@@ -142,15 +128,13 @@ function fetchProperties(isLoadMore = false) {
   const lastItem = propertyList.value[propertyList.value.length - 1]
 
   const params = {
-    transactionType: dealType.value.length
-      ? dealType.value.join(',')
-      : undefined,
-    jeonseDepositMin: jd.value.min ?? undefined,
-    jeonseDepositMax: jd.value.max ?? undefined,
-    monthlyDepositMin: md.value.min ?? undefined,
-    monthlyDepositMax: md.value.max ?? undefined,
-    monthlyMin: mr.value.min ? Math.floor(mr.value.min / 10000) : undefined,
-    monthlyMax: mr.value.max ? Math.floor(mr.value.max / 10000) : undefined,
+    transactionType: getMappedTransactionType(dealType.value),
+    jeonseDepositMin: toWon(jd.value.min) ?? undefined,
+    jeonseDepositMax: toWon(jd.value.max) ?? undefined,
+    monthlyDepositMin: toWon(md.value.min) ?? undefined,
+    monthlyDepositMax: toWon(md.value.max) ?? undefined,
+    monthlyMin: mr.value.min ?? undefined,
+    monthlyMax: mr.value.max ?? undefined,
 
     sido: region.value.city,
     sigungu: region.value.district,


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치

- #107-minyoung

### ✅ 작업한 내용

- 월세 필터링 안되는 오류 수정
- 전월세 보증금 요청 보낼때 만원-> 원 단위로 보내도록 수정
- 백엔드 요청 부분 중복으로 들어가있는 부분 수정

### ❗️PR Point

- 오류 발생 시 말씀해주세요

### 📸 스크린샷

<!-- 스크린 샷이 있다면 첨부해주세요 -->

closed #107 
