### PR TITLE
✨Feat: 임대인 매물 관리 페이지 API 로직 구현 및 store 적용

### DIFF
--- a/src/api/registeredProperty.js
+++ b/src/api/registeredProperty.js
@@ -1,0 +1,23 @@
+import apiClient from './apiClient'
+
+const registeredPropertyAPI = {
+  // 1. 사용자 등록 매물 리스트 조회
+  async fetchMyProperties() {
+    const { data } = await apiClient.get('/properties/landlord')
+    return data
+  },
+
+  // 2. 사용자 등록 매물 총 개수 조회
+  async countMyProperties() {
+    const { data } = await apiClient.get('/properties/landlord/count')
+    return data
+  },
+
+  // 3. 사용자 등록 매물 삭제
+  async deleteProperty(propertyId) {
+    const { data } = await apiClient.delete(`/properties/${propertyId}`)
+    return data
+  },
+}
+
+export default registeredPropertyAPI

--- a/src/stores/registeredProperty.js
+++ b/src/stores/registeredProperty.js
@@ -1,0 +1,61 @@
+import { defineStore } from 'pinia'
+import registeredPropertyAPI from '@/api/registeredProperty'
+
+export const useRegisteredPropertyStore = defineStore('registeredProperty', {
+  state: () => ({
+    myProperties: [],
+    propertyCount: 0,
+    loading: false,
+    error: null,
+  }),
+
+  getters: {
+    getProperties: state => state.myProperties,
+    getPropertyCount: state => state.propertyCount,
+  },
+
+  actions: {
+    async fetchMyProperties() {
+      this.loading = true
+      this.error = null
+      try {
+        const data = await registeredPropertyAPI.fetchMyProperties()
+        this.myProperties = data
+        this.propertyCount = data.length
+      } catch (err) {
+        this.error = err
+        console.error('내 매물 정보를 가져오는 중 오류 발생:', err)
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async deleteProperty(propertyId) {
+      this.loading = true
+      this.error = null
+      try {
+        await registeredPropertyAPI.deleteProperty(propertyId)
+        await this.fetchMyProperties()
+      } catch (err) {
+        this.error = err
+        console.error('매물 삭제 중 오류 발생:', err)
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async fetchPropertyCount() {
+      this.loading = true
+      this.error = null
+      try {
+        const data = await registeredPropertyAPI.countMyProperties()
+        this.propertyCount = data
+      } catch (err) {
+        this.error = err
+        console.error('매물 개수를 가져오는 중 오류 발생:', err)
+      } finally {
+        this.loading = false
+      }
+    },
+  },
+})


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치
Feat/#146 yumi

- #146 

### ✅ 작업한 내용

- registeredProperty.js 파일에 매물 조회, 개수 조회, 삭제 API 호출 로직 추가
- registeredProperty.js 스토어 생성
- PropertyManage.vue에서 더미 데이터 제거, RegisteredProperty Store 사용

### ❗️PR Point

- 오류 생기면 말씀해주세요!

### 📸 스크린샷

<img width="539" height="907" alt="image" src="https://github.com/user-attachments/assets/610e72aa-30e6-4e21-815b-4c420f23e7ff" />

closed #146
