### PR TITLE
✨ Feat: 상세/수정 페이지 관리비 표시 로직 통일

### DIFF
--- a/src/pages/myPage/EditProperty.vue
+++ b/src/pages/myPage/EditProperty.vue
@@ -239,14 +239,31 @@ const formattedPrice = computed(() => {
 
 const calculate = computed(() => {
   const propertyDetails = property.getPropertyDetails
-  const total = propertyDetails.management?.reduce((acc, crr) => {
-    const fee = parseInt(crr.managementFee, 10)
-    return acc + (isNaN(fee) ? 0 : fee)
+  const managementList = propertyDetails?.management || []
+
+  const total = managementList.reduce((acc, crr) => {
+    if (crr && crr.managementFee && crr.managementFee !== '쓴 만큼') {
+      const parsedFee = parseInt(crr.managementFee, 10)
+      if (!isNaN(parsedFee)) {
+        return acc + parsedFee
+      }
+    }
+    return acc
   }, 0)
+
   if (total === 0) {
+    const hasOnlyVariableFees = managementList.every(
+      m => m && m.managementFee === '쓴 만큼',
+    )
+
+    if (hasOnlyVariableFees) {
+      return '별도 부과'
+    }
+
     return '관련 정보 없음'
   }
-  return '매월' + formatMonthlyDetail(total)
+
+  return '매월 ' + formatMonthlyDetail(total)
 })
 
 const handleEditSection = async section => {
@@ -449,11 +466,9 @@ const handleEditSection = async section => {
                 <span class="management-type">{{ m.managementType }}:</span>
                 <span>
                   {{
-                    m.managementFee !== '0' &&
-                    m.managementFee !== null &&
-                    m.managementFee !== undefined
-                      ? formatMonthlyDetail(m.managementFee)
-                      : '쓴 만큼'
+                    m.managementFee === '쓴 만큼'
+                      ? '쓴 만큼'
+                      : formatMonthlyDetail(m.managementFee)
                   }}
                 </span>
               </div>


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치
Feat/#185-yumi

- #이슈번호

### ✅ 작업한 내용

기존에 상세 페이지와 수정 페이지 간에 달랐던 관리비 표시 정책 통일

### ❗️PR Point

- <!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

### 📸 스크린샷

<img width="728" height="516" alt="image" src="https://github.com/user-attachments/assets/9935a128-5ce8-4748-9718-8bf4763d1caf" />

closed #185
